### PR TITLE
Convert from 16-step to 32-step sequencer

### DIFF
--- a/api/lib/generatePatterns.js
+++ b/api/lib/generatePatterns.js
@@ -8,55 +8,64 @@ export async function generatePatterns(input, currentOctave, notes, apiKey, isCr
 
     // Create different instructions based on creative mode
     const melodyInstructions = isCreative
-        ? `Given this music description: "${input}", generate a COMPLEX melody with CHORDS for a 16-step sequencer.
+        ? `Given this music description: "${input}", generate a COMPLEX melody with CHORDS for a 32-step sequencer.
+
+CRITICAL: The sequencer has 32 steps (0-31), NOT 16 steps. You MUST use the FULL RANGE from step 0 to step 31.
+IMPORTANT: 32 steps = 2 bars. Create VARIATION between the two bars - don't just repeat the same pattern twice!
 
 Available notes: ${notes.map(n => n + currentOctave).join(', ')}.
 
 YOU MUST CREATE CHORDS. A chord is when AT LEAST 3 NOTES play at the EXACT SAME step number.
 
 INSTRUCTIONS:
-1. Pick 4-6 step positions where chords will play (e.g. but don't copy exactly, steps 0, 4, 8, 12)
+1. Pick 6-8 step positions ACROSS THE FULL 32-STEP RANGE where chords will play (e.g., steps 0, 4, 8, 12, 16, 20, 24, 28)
 2. For EACH of those positions, place AT LEAST 3 different notes
-3. Add 2-4 more notes at other positions for melody
-4. ALL notes must use the SAME step numbers you chose for chords
+3. Add 2-4 more notes at other positions THROUGHOUT THE 32 STEPS for melody
+4. IMPORTANT: Use steps from 0 all the way to 31 - don't stop at 15!
+5. CREATE VARIETY: Steps 0-15 (bar 1) and steps 16-31 (bar 2) should have different patterns for musical interest
 
-EXAMPLE - See how steps 0, 4, 8, 12 each have THREE notes (C, E, G):
+EXAMPLE showing FULL 32-step range:
 {
   "notes": [
-    {"note": "C${currentOctave}", "steps": [0, 4, 8, 12]},
-    {"note": "E${currentOctave}", "steps": [0, 4, 8, 12]},
-    {"note": "G${currentOctave}", "steps": [0, 4, 8, 12]},
-    {"note": "A${currentOctave}", "steps": [2, 6, 10, 14]},
-    {"note": "D${currentOctave}", "steps": [1, 3, 5, 7]}
+    {"note": "C${currentOctave}", "steps": [0, 8, 16, 24]},
+    {"note": "E${currentOctave}", "steps": [0, 8, 16, 24]},
+    {"note": "G${currentOctave}", "steps": [0, 8, 16, 24]},
+    {"note": "A${currentOctave}", "steps": [4, 12, 20, 28, 31]},
+    {"note": "D${currentOctave}", "steps": [2, 6, 10, 14, 18, 22, 26, 30]}
   ]
 }
 
-At step 0: C, E, G play together = CHORD
-At step 4: C, E, G play together = CHORD
-At step 8: C, E, G play together = CHORD
-At step 12: C, E, G play together = CHORD
+Notice: D uses steps including 18, 22, 26, 30 (beyond step 15!)
+Notice: A uses step 31 (the last step!)
 
-YOU MUST USE THIS EXACT PATTERN. Pick your chord notes and make them share the SAME step arrays.
+REMEMBER: Steps range from 0 to 31 (32 total steps). Use the ENTIRE range!
 
 Return ONLY valid JSON, no markdown or explanation.`
-        : `Given this music description: "${input}", generate a simple complementary melody pattern for a 16-step sequencer.
+        : `Given this music description: "${input}", generate a simple complementary melody pattern for a 32-step sequencer.
+
+CRITICAL: The sequencer has 32 steps (0-31), NOT 16. You MUST use the FULL RANGE from step 0 to step 31.
+IMPORTANT: 32 steps = 2 bars. Create some VARIATION between the bars - don't just copy the first 16 steps twice!
 
 The available notes in octave ${currentOctave} are: ${notes.map(n => n + currentOctave).join(', ')}.
 
 Create a melodic pattern that fits the mood. Return ONLY a JSON object in this exact format with no markdown:
 {
   "notes": [
-    {"note": "C${currentOctave}", "steps": [0, 4, 8, 12]},
-    {"note": "E${currentOctave}", "steps": [2, 6, 10, 14]},
-    {"note": "G${currentOctave}", "steps": [1, 5, 9, 13]}
+    {"note": "C${currentOctave}", "steps": [0, 8, 16, 24, 31]},
+    {"note": "E${currentOctave}", "steps": [4, 12, 20, 28]},
+    {"note": "G${currentOctave}", "steps": [2, 10, 18, 26, 30]}
   ]
 }
 
+Notice: Steps include 18, 20, 24, 26, 28, 30, 31 - using the FULL 32-step range!
+
 Where:
-- Each note object has a "note" (e.g., "C${currentOctave}") and "steps" (array of step positions 0-15)
+- Each note object has a "note" (e.g., "C${currentOctave}") and "steps" (array of step positions from 0 to 31)
 - Include 4-6 different notes
-- Steps should be sparse (not every step filled)
+- Steps should be spread ACROSS ALL 32 STEPS, not just 0-15
 - Make it musical and fitting for ${input}
+
+IMPORTANT: Use the complete range 0-31, don't stop at step 15!
 
 Return ONLY the JSON, no other text.`;
 

--- a/backend/lib/generatePatterns.js
+++ b/backend/lib/generatePatterns.js
@@ -8,55 +8,64 @@ export async function generatePatterns(input, currentOctave, notes, apiKey, isCr
 
     // Create different instructions based on creative mode
     const melodyInstructions = isCreative
-        ? `Given this music description: "${input}", generate a COMPLEX melody with CHORDS for a 16-step sequencer.
+        ? `Given this music description: "${input}", generate a COMPLEX melody with CHORDS for a 32-step sequencer.
+
+CRITICAL: The sequencer has 32 steps (0-31), NOT 16 steps. You MUST use the FULL RANGE from step 0 to step 31.
+IMPORTANT: 32 steps = 2 bars. Create VARIATION between the two bars - don't just repeat the same pattern twice!
 
 Available notes: ${notes.map(n => n + currentOctave).join(', ')}.
 
 YOU MUST CREATE CHORDS. A chord is when AT LEAST 3 NOTES play at the EXACT SAME step number.
 
 INSTRUCTIONS:
-1. Pick 4-6 step positions where chords will play (e.g. but don't copy exactly, steps 0, 4, 8, 12)
+1. Pick 6-8 step positions ACROSS THE FULL 32-STEP RANGE where chords will play (e.g., steps 0, 4, 8, 12, 16, 20, 24, 28)
 2. For EACH of those positions, place AT LEAST 3 different notes
-3. Add 2-4 more notes at other positions for melody
-4. ALL notes must use the SAME step numbers you chose for chords
+3. Add 2-4 more notes at other positions THROUGHOUT THE 32 STEPS for melody
+4. IMPORTANT: Use steps from 0 all the way to 31 - don't stop at 15!
+5. CREATE VARIETY: Steps 0-15 (bar 1) and steps 16-31 (bar 2) should have different patterns for musical interest
 
-EXAMPLE - See how steps 0, 4, 8, 12 each have THREE notes (C, E, G):
+EXAMPLE showing FULL 32-step range:
 {
   "notes": [
-    {"note": "C${currentOctave}", "steps": [0, 4, 8, 12]},
-    {"note": "E${currentOctave}", "steps": [0, 4, 8, 12]},
-    {"note": "G${currentOctave}", "steps": [0, 4, 8, 12]},
-    {"note": "A${currentOctave}", "steps": [2, 6, 10, 14]},
-    {"note": "D${currentOctave}", "steps": [1, 3, 5, 7]}
+    {"note": "C${currentOctave}", "steps": [0, 8, 16, 24]},
+    {"note": "E${currentOctave}", "steps": [0, 8, 16, 24]},
+    {"note": "G${currentOctave}", "steps": [0, 8, 16, 24]},
+    {"note": "A${currentOctave}", "steps": [4, 12, 20, 28, 31]},
+    {"note": "D${currentOctave}", "steps": [2, 6, 10, 14, 18, 22, 26, 30]}
   ]
 }
 
-At step 0: C, E, G play together = CHORD
-At step 4: C, E, G play together = CHORD
-At step 8: C, E, G play together = CHORD
-At step 12: C, E, G play together = CHORD
+Notice: D uses steps including 18, 22, 26, 30 (beyond step 15!)
+Notice: A uses step 31 (the last step!)
 
-YOU MUST USE THIS EXACT PATTERN. Pick your chord notes and make them share the SAME step arrays.
+REMEMBER: Steps range from 0 to 31 (32 total steps). Use the ENTIRE range!
 
 Return ONLY valid JSON, no markdown or explanation.`
-        : `Given this music description: "${input}", generate a simple complementary melody pattern for a 16-step sequencer.
+        : `Given this music description: "${input}", generate a simple complementary melody pattern for a 32-step sequencer.
+
+CRITICAL: The sequencer has 32 steps (0-31), NOT 16. You MUST use the FULL RANGE from step 0 to step 31.
+IMPORTANT: 32 steps = 2 bars. Create some VARIATION between the bars - don't just copy the first 16 steps twice!
 
 The available notes in octave ${currentOctave} are: ${notes.map(n => n + currentOctave).join(', ')}.
 
 Create a melodic pattern that fits the mood. Return ONLY a JSON object in this exact format with no markdown:
 {
   "notes": [
-    {"note": "C${currentOctave}", "steps": [0, 4, 8, 12]},
-    {"note": "E${currentOctave}", "steps": [2, 6, 10, 14]},
-    {"note": "G${currentOctave}", "steps": [1, 5, 9, 13]}
+    {"note": "C${currentOctave}", "steps": [0, 8, 16, 24, 31]},
+    {"note": "E${currentOctave}", "steps": [4, 12, 20, 28]},
+    {"note": "G${currentOctave}", "steps": [2, 10, 18, 26, 30]}
   ]
 }
 
+Notice: Steps include 18, 20, 24, 26, 28, 30, 31 - using the FULL 32-step range!
+
 Where:
-- Each note object has a "note" (e.g., "C${currentOctave}") and "steps" (array of step positions 0-15)
+- Each note object has a "note" (e.g., "C${currentOctave}") and "steps" (array of step positions from 0 to 31)
 - Include 4-6 different notes
-- Steps should be sparse (not every step filled)
+- Steps should be spread ACROSS ALL 32 STEPS, not just 0-15
 - Make it musical and fitting for ${input}
+
+IMPORTANT: Use the complete range 0-31, don't stop at step 15!
 
 Return ONLY the JSON, no other text.`;
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -453,7 +453,7 @@
 
         .track {
             display: grid;
-            grid-template-columns: 80px repeat(16, 1fr);
+            grid-template-columns: 80px repeat(32, 1fr);
             gap: 4px;
             align-items: center;
             margin-bottom: 8px;
@@ -691,7 +691,7 @@
         .piano-grid {
             display: grid;
             grid-template-rows: repeat(12, 24px);
-            grid-template-columns: repeat(16, 1fr);
+            grid-template-columns: repeat(32, 1fr);
             gap: 0;
         }
 
@@ -733,64 +733,64 @@
             opacity: 0.9;
         }
 
-        /* Gradient from dark green (C/bottom) to light green (B/top) */
-        .piano-cell:nth-child(n+1):nth-child(-n+16).active,
-        .piano-cell:nth-child(n+1):nth-child(-n+16).active::before {
+        /* Gradient from dark green (C/bottom) to light green (B/top) - 32 steps per row */
+        .piano-cell:nth-child(n+1):nth-child(-n+32).active,
+        .piano-cell:nth-child(n+1):nth-child(-n+32).active::before {
             background: #008055; /* Darkest - C */
         }
 
-        .piano-cell:nth-child(n+17):nth-child(-n+32).active,
-        .piano-cell:nth-child(n+17):nth-child(-n+32).active::before {
+        .piano-cell:nth-child(n+33):nth-child(-n+64).active,
+        .piano-cell:nth-child(n+33):nth-child(-n+64).active::before {
             background: #00995f;
         }
 
-        .piano-cell:nth-child(n+33):nth-child(-n+48).active,
-        .piano-cell:nth-child(n+33):nth-child(-n+48).active::before {
+        .piano-cell:nth-child(n+65):nth-child(-n+96).active,
+        .piano-cell:nth-child(n+65):nth-child(-n+96).active::before {
             background: #00b36a;
         }
 
-        .piano-cell:nth-child(n+49):nth-child(-n+64).active,
-        .piano-cell:nth-child(n+49):nth-child(-n+64).active::before {
+        .piano-cell:nth-child(n+97):nth-child(-n+128).active,
+        .piano-cell:nth-child(n+97):nth-child(-n+128).active::before {
             background: #00cc75;
         }
 
-        .piano-cell:nth-child(n+65):nth-child(-n+80).active,
-        .piano-cell:nth-child(n+65):nth-child(-n+80).active::before {
+        .piano-cell:nth-child(n+129):nth-child(-n+160).active,
+        .piano-cell:nth-child(n+129):nth-child(-n+160).active::before {
             background: #00e680;
         }
 
-        .piano-cell:nth-child(n+81):nth-child(-n+96).active,
-        .piano-cell:nth-child(n+81):nth-child(-n+96).active::before {
+        .piano-cell:nth-child(n+161):nth-child(-n+192).active,
+        .piano-cell:nth-child(n+161):nth-child(-n+192).active::before {
             background: #00ff8b;
         }
 
-        .piano-cell:nth-child(n+97):nth-child(-n+112).active,
-        .piano-cell:nth-child(n+97):nth-child(-n+112).active::before {
+        .piano-cell:nth-child(n+193):nth-child(-n+224).active,
+        .piano-cell:nth-child(n+193):nth-child(-n+224).active::before {
             background: #1aff99;
         }
 
-        .piano-cell:nth-child(n+113):nth-child(-n+128).active,
-        .piano-cell:nth-child(n+113):nth-child(-n+128).active::before {
+        .piano-cell:nth-child(n+225):nth-child(-n+256).active,
+        .piano-cell:nth-child(n+225):nth-child(-n+256).active::before {
             background: #33ffa6;
         }
 
-        .piano-cell:nth-child(n+129):nth-child(-n+144).active,
-        .piano-cell:nth-child(n+129):nth-child(-n+144).active::before {
+        .piano-cell:nth-child(n+257):nth-child(-n+288).active,
+        .piano-cell:nth-child(n+257):nth-child(-n+288).active::before {
             background: #4dffb3;
         }
 
-        .piano-cell:nth-child(n+145):nth-child(-n+160).active,
-        .piano-cell:nth-child(n+145):nth-child(-n+160).active::before {
+        .piano-cell:nth-child(n+289):nth-child(-n+320).active,
+        .piano-cell:nth-child(n+289):nth-child(-n+320).active::before {
             background: #66ffc0;
         }
 
-        .piano-cell:nth-child(n+161):nth-child(-n+176).active,
-        .piano-cell:nth-child(n+161):nth-child(-n+176).active::before {
+        .piano-cell:nth-child(n+321):nth-child(-n+352).active,
+        .piano-cell:nth-child(n+321):nth-child(-n+352).active::before {
             background: #80ffcc;
         }
 
-        .piano-cell:nth-child(n+177):nth-child(-n+192).active,
-        .piano-cell:nth-child(n+177):nth-child(-n+192).active::before {
+        .piano-cell:nth-child(n+353):nth-child(-n+384).active,
+        .piano-cell:nth-child(n+353):nth-child(-n+384).active::before {
             background: #99ffd9; /* Lightest - B */
         }
 
@@ -968,7 +968,7 @@
             }
 
             .track {
-                grid-template-columns: 60px repeat(16, 1fr);
+                grid-template-columns: 60px repeat(32, 1fr);
             }
 
             .step:nth-child(4n+2) {
@@ -1159,7 +1159,7 @@
     <script>
 
         // Configuration
-        const STEPS = 16;
+        const STEPS = 32;
         const instruments = ['kick', 'snare', 'hihat', 'openhat', 'clap'];
         
         // Piano roll configuration
@@ -1175,39 +1175,39 @@
         // Preset patterns
         const presets = {
             techno: {
-                kick:    [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
-                snare:   [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0],
-                hihat:   [0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0],
-                openhat: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
-                clap:    [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0]
+                kick:    [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
+                snare:   [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0],
+                hihat:   [0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0],
+                openhat: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
+                clap:    [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0]
             },
             house: {
-                kick:    [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
-                snare:   [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0],
-                hihat:   [0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0],
-                openhat: [0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1],
-                clap:    [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0]
+                kick:    [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0],
+                snare:   [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0],
+                hihat:   [0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0],
+                openhat: [0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1],
+                clap:    [0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,1,0,0,0]
             },
             trap: {
-                kick:    [1,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0],
-                snare:   [0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
-                hihat:   [1,0,1,0,1,0,1,0,1,1,0,1,0,1,1,1],
-                openhat: [0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0],
-                clap:    [0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0]
+                kick:    [1,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0],
+                snare:   [0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+                hihat:   [1,0,1,0,1,0,1,0,1,1,0,1,0,1,1,1,1,0,1,0,1,0,1,0,1,1,0,1,0,1,1,1],
+                openhat: [0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0],
+                clap:    [0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0]
             },
             breakbeat: {
-                kick:    [1,0,0,0,0,0,1,0,0,0,1,0,0,0,0,0],
-                snare:   [0,0,0,0,1,0,0,0,0,1,0,0,1,0,0,0],
-                hihat:   [1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0],
-                openhat: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0],
-                clap:    [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+                kick:    [1,0,0,0,0,0,1,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,1,0,0,0,0,0],
+                snare:   [0,0,0,0,1,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,1,0,0,1,0,0,0],
+                hihat:   [1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0],
+                openhat: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0],
+                clap:    [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
             },
             minimal: {
-                kick:    [1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0],
-                snare:   [0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
-                hihat:   [0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1],
-                openhat: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
-                clap:    [0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0]
+                kick:    [1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0],
+                snare:   [0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0],
+                hihat:   [0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1],
+                openhat: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                clap:    [0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0]
             }
         };
 


### PR DESCRIPTION
Major changes:
- Update STEPS constant from 16 to 32
- Extend all preset patterns to 32 steps (2-bar patterns)
- Update CSS grid layouts for 32 columns (drums and piano)
- Update piano cell gradient ranges for 32-step rows

AI prompt improvements:
- Emphatic instructions to use full 0-31 step range
- Explicit warnings not to stop at step 15
- Instructions to create variation between bars (not repeat)
- Examples showing steps 16+ to demonstrate full range

Export/Import:
- MIDI export uses STEPS constant (auto-updated)
- TXT export/import work dynamically with any step count